### PR TITLE
Removing echo "-n" flag.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -10,7 +10,7 @@ if [[ ! -z ${scanner_properties} ]]; then
   if [[ -e sonar-project.properties ]]; then
     echo -e "\e[34mBoth sonar-project.properties file and step properties are provided. Appending properties to the file.\e[0m"
   fi
-  echo -n "${scanner_properties}" >> sonar-project.properties
+  echo "${scanner_properties}" >> sonar-project.properties
 fi
 
 JAVA_VERSION_MAJOR=$(java -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\1/; 1q')
@@ -28,5 +28,13 @@ unzip sonar-scanner-cli-${scanner_version}.zip
 TEMP_DIR=$(pwd)
 popd
 
-${TEMP_DIR}/sonar-scanner-${scanner_version}/bin/sonar-scanner
+
+
+if [[ "${is_debug}" == "true" ]]; then
+  debug_flag="-X"
+else
+  debug_flag=""
+fi
+
+${TEMP_DIR}/sonar-scanner-${scanner_version}/bin/sonar-scanner $debug_flag
 

--- a/step.yml
+++ b/step.yml
@@ -33,7 +33,7 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 inputs:
-- scanner_version: 3.3.0.1492
+- scanner_version: 4.3.0.2102
   opts:
     title: Scanner CLI version
     description: |-

--- a/step.yml
+++ b/step.yml
@@ -64,6 +64,8 @@ inputs:
     title: Print all executed shell commands to a build log?
     description: |-
       Whether trace of shell commands should be printed to a build log.
+      In addition, debug logging will be enabled for SonarQube (by adding the -X argument).
+      
       Options:
       * "true"
       * "false" (default)


### PR DESCRIPTION
The /bin/echo binary and shell builtins can behave differently and not support the -n flag. (https://www.shellscript.sh/tips/echo/)

Adding debug logging for the sonarqube binary.