### PR TITLE
Fix input properties append when there is no newline at the end of the existing file

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -9,6 +9,7 @@ fi
 if [[ ! -z ${scanner_properties} ]]; then
   if [[ -e sonar-project.properties ]]; then
     echo -e "\e[34mBoth sonar-project.properties file and step properties are provided. Appending properties to the file.\e[0m"
+    echo "" >> sonar-project.properties
   fi
   echo "${scanner_properties}" >> sonar-project.properties
 fi


### PR DESCRIPTION
There's an issue that happens If you have a `sonar-project.properties` file without a newline at the end and provide an input for `scanner_properties`, the `scanner_properties` value is appended along with the value of the last line, e.g:

`sonar-project.properties`:
```properties
foo=bar
```

`scanner_properties`:
```properties
bar=baz
```

the resulting file will look like:
```properties
foo=barbar=baz
```

I'm adding this empty echo just to add a newline to the existing file before appending the input to avoid this issue.