### PR TITLE
Handles "latest" special value for scanner_version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -81,7 +81,7 @@ workflows:
     - test-default-version
     - test-explicit-version
   test-default-version:
-    description: Test with default, implicit scanner version
+    description: Test with default, latest scanner version
     before_run:
     - _prepare_environment
     steps:

--- a/step.sh
+++ b/step.sh
@@ -15,6 +15,12 @@ if [[ ! -z ${scanner_properties} ]]; then
 fi
 
 
+if [[ "$scanner_version" == "latest" ]]; then
+  scanner_version=$(curl --silent "https://api.github.com/repos/SonarSource/sonar-scanner-cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  echo "Use latest version: $scanner_version"
+fi
+
+
 # Identify minimum Java version required based on Sonarqube scanner used
 MINIMUM_JAVA_VERSION_NEEDED="8"
 if [[ $(echo "$scanner_version" | cut -d'.' -f1) -ge "4" ]]; then
@@ -32,12 +38,6 @@ if [ ! -z "${JAVA_VERSION_MAJOR}" ]; then
   fi
 else
   echo -e "\e[91mSonar Scanner CLI \"${scanner_version}\" requires JRE or JDK version ${MINIMUM_JAVA_VERSION_NEEDED} or newer. None has been detected, CLI may not work properly.\e[0m"
-fi
-
-
-if [[ "$scanner_version" == "latest" ]]; then
-  scanner_version=$(curl --silent "https://api.github.com/repos/SonarSource/sonar-scanner-cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-  echo "Use latest version: $scanner_version"
 fi
 
 

--- a/step.sh
+++ b/step.sh
@@ -23,6 +23,13 @@ else
   echo -e "\e[91mSonar Scanner CLI requires JRE or JDK version 8 or newer. None has been detected, CLI may not work properly.\e[0m"
 fi
 
+
+if [[ "$scanner_version" == "latest" ]]; then
+  scanner_version=$(curl --silent "https://api.github.com/repos/SonarSource/sonar-scanner-cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  echo "Use latest version: $scanner_version"
+fi
+
+
 pushd $(mktemp -d)
 wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${scanner_version}.zip
 unzip sonar-scanner-cli-${scanner_version}.zip

--- a/step.yml
+++ b/step.yml
@@ -33,7 +33,7 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 inputs:
-- scanner_version: latest
+- scanner_version: 4.3.0.2102
   opts:
     title: Scanner CLI version
     description: |-

--- a/step.yml
+++ b/step.yml
@@ -33,11 +33,13 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 inputs:
-- scanner_version: 4.3.0.2102
+- scanner_version: latest
   opts:
     title: Scanner CLI version
     description: |-
       Scanner CLI version to be used. Step will fail if invalid or non-existent is specified.
+
+      `latest` can be used to use the latest available scanner
     is_required: true
 - scanner_properties:
   opts:


### PR DESCRIPTION
Instead of updating the default version for every release of the Scanner, this PR handle a `latest` value for the `scanner_version` input.

In this case, the script will use the Github API to fetch the last public release of Sonnar-scanner from the [official repository](https://github.com/SonarSource/sonar-scanner-cli).

The use can still use a specific version if needed.