### PR TITLE
Fix Java version check

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -121,11 +121,11 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            JAVA_VERSION_MAJOR=$(java -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\1/; 1q')
-            if [ "${JAVA_VERSION_MAJOR}" -lt "8" ]; then
+            JAVA_VERSION_MAJOR=$(javac -version 2>&1 | cut -d' ' -f2 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+            if [ "${JAVA_VERSION_MAJOR}" -lt "11" ]; then
               mkfifo fifo
               bash step.sh >fifo &
-              grep -m1 'Version "7" has been detected' fifo
+              grep -m1 'Version "8" has been detected' fifo
               kill $!
               rm fifo
             fi

--- a/step.sh
+++ b/step.sh
@@ -14,14 +14,26 @@ if [[ ! -z ${scanner_properties} ]]; then
   echo "${scanner_properties}" >> sonar-project.properties
 fi
 
-JAVA_VERSION_MAJOR=$(java -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\1/; 1q')
+
+# Identify minimum Java version required based on Sonarqube scanner used
+MINIMUM_JAVA_VERSION_NEEDED="8"
+if [[ $(echo "$scanner_version" | cut -d'.' -f1) -ge "4" ]]; then
+  if [[ $(echo "$scanner_version" | cut -d'.' -f2) -gt "0" ]]; then
+    MINIMUM_JAVA_VERSION_NEEDED="11"
+  fi
+fi
+
+
+# Check current Java version against the minimum one required
+JAVA_VERSION_MAJOR=$(javac -version 2>&1 | cut -d' ' -f2 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 if [ ! -z "${JAVA_VERSION_MAJOR}" ]; then
-  if [ "${JAVA_VERSION_MAJOR}" -lt "8" ]; then
-    echo -e "\e[93mSonar Scanner CLI requires JRE or JDK version 8 or newer. Version \"${JAVA_VERSION_MAJOR}\" has been detected, CLI may not work properly.\e[0m"
+  if [ "${JAVA_VERSION_MAJOR}" -le "${MINIMUM_JAVA_VERSION_NEEDED}" ]; then
+    echo -e "\e[93mSonar Scanner CLI \"${scanner_version}\" requires JRE or JDK version ${MINIMUM_JAVA_VERSION_NEEDED} or newer. Version \"${JAVA_VERSION_MAJOR}\" has been detected, CLI may not work properly.\e[0m"
   fi
 else
-  echo -e "\e[91mSonar Scanner CLI requires JRE or JDK version 8 or newer. None has been detected, CLI may not work properly.\e[0m"
+  echo -e "\e[91mSonar Scanner CLI \"${scanner_version}\" requires JRE or JDK version ${MINIMUM_JAVA_VERSION_NEEDED} or newer. None has been detected, CLI may not work properly.\e[0m"
 fi
+
 
 pushd $(mktemp -d)
 wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${scanner_version}.zip

--- a/step.sh
+++ b/step.sh
@@ -27,7 +27,7 @@ fi
 # Check current Java version against the minimum one required
 JAVA_VERSION_MAJOR=$(javac -version 2>&1 | cut -d' ' -f2 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 if [ ! -z "${JAVA_VERSION_MAJOR}" ]; then
-  if [ "${JAVA_VERSION_MAJOR}" -le "${MINIMUM_JAVA_VERSION_NEEDED}" ]; then
+  if [ "${JAVA_VERSION_MAJOR}" -lt "${MINIMUM_JAVA_VERSION_NEEDED}" ]; then
     echo -e "\e[93mSonar Scanner CLI \"${scanner_version}\" requires JRE or JDK version ${MINIMUM_JAVA_VERSION_NEEDED} or newer. Version \"${JAVA_VERSION_MAJOR}\" has been detected, CLI may not work properly.\e[0m"
   fi
 else


### PR DESCRIPTION
Update Java version check to work with both 1.8 and 11 formats. the Bitrise images only have Java 8 and 11, but user may have installed another specific version, so we have to be resilient about that.

This PR also resolves the minimum Java version required based on the Sonar Scanner CLI version used.

This PR should be applied before #20 