### PR TITLE
Add option to support specifying project settings path

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -6,11 +6,11 @@ if [[ "${is_debug}" == "true" ]]; then
 fi
 
 if [[ -n ${scanner_properties} ]]; then
-  if [[ -e sonar-project.properties ]]; then
-    echo -e "\e[34mBoth sonar-project.properties file and step properties are provided. Appending properties to the file.\e[0m"
-    echo "" >> sonar-project.properties
+  if [[ -e "${project_settings_path}" ]]; then
+    echo -e "\e[34mBoth project configuration file and step properties are provided. Appending properties to the file.\e[0m"
+    echo "" >> "${project_settings_path}"
   fi
-  echo "${scanner_properties}" >> sonar-project.properties
+  echo "${scanner_properties}" >> "${project_settings_path}"
 fi
 
 if [[ "$scanner_version" == "latest" ]]; then
@@ -48,5 +48,5 @@ else
   debug_flag=""
 fi
 
-"${TEMP_DIR}/sonar-scanner-${scanner_version}/bin/sonar-scanner" ${debug_flag}
+"${TEMP_DIR}/sonar-scanner-${scanner_version}/bin/sonar-scanner" ${debug_flag} -Dproject.settings="${project_settings_path}"
 

--- a/step.yml
+++ b/step.yml
@@ -63,6 +63,15 @@ inputs:
 
     is_required: false
     is_expand: true
+- project_settings_path: sonar-project.properties
+  opts:
+    title: Path of project configuration file
+    description: |-
+      See [alternatives to sonar-project.properties](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/#sonar-project-properties) documentation
+      before changing this value.
+
+      Specify the path to the project configuration file through the `-Dproject.settings=` argument.
+    is_required: true
 - is_debug: "false"
   opts:
     title: Print all executed shell commands to a build log?


### PR DESCRIPTION
Allows overriding the path of the `sonar-project.properties` file as documented under [Alternatives to sonar-project.properties](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/#sonar-project-properties).