### PR TITLE
Set Java 17 in test environment for SonarScanner 5.x compatibility

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,6 +21,9 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
+    - set-java-version@1:
+        inputs:
+        - set_java_version: "17"
     - generate-text-file:
         inputs:
         - file_name: Test.java


### PR DESCRIPTION
## Summary
- Adds `set-java-version@1` step to `_prepare_environment` workflow, pinning Java 17
- SonarScanner 5.x (used when `scanner_version: latest`) requires Java 17 (class file version 61.0); CI was failing with `UnsupportedClassVersionError` on Java 11

## Test plan
- [ ] Verify CI passes with `test-default-version` (latest scanner) and `test-explicit-version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)