### PR TITLE
Adds new security category

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -22,6 +22,7 @@ source_code_url: https://github.com/DroidsOnRoids/bitrise-step-sonarqube-scanner
 support_url: https://github.com/DroidsOnRoids/bitrise-step-sonarqube-scanner/issues
 type_tags:
 - utility
+- security
 deps:
   apt_get:
   - name: unzip


### PR DESCRIPTION
The sonarqube step will appear under a new "security" category in bitrise.io/integrations